### PR TITLE
Make watermark image smaller

### DIFF
--- a/source/javascripts/settings.js.erb
+++ b/source/javascripts/settings.js.erb
@@ -52,7 +52,7 @@ var MEME_SETTINGS = {
   textShadow: false, // Text shadow toggle.
   textShadowEdit: true, // Toggles text shadow control within the editor.
   watermarkAlpha: 1, // Opacity of watermark image.
-  watermarkMaxWidthRatio: 0.15, // Maximum allowed width of watermark (percentage of total canvas width).
+  watermarkMaxWidthRatio: 0.1, // Maximum allowed width of watermark (percentage of total canvas width).
 
   // Path to the watermark image source, or blank for no watermark:
   // Alternatively, use '<%= asset_data_uri("vox.png") %>' to populate the watermark with base64 data, avoiding Cross-Origin issues.


### PR DESCRIPTION
Now that the canvas is so much larger, 15% of the canvas width is way too big for the "F".